### PR TITLE
Enhancement: Course codes with spaces now work

### DIFF
--- a/src/components/CourseFinder/CourseContainer.jsx
+++ b/src/components/CourseFinder/CourseContainer.jsx
@@ -41,9 +41,15 @@ const CourseFinderContainer = () => {
 
   useEffect(() => {
     const filter = getQueryString()
+    let q
+    if (/^[A-Za-z]{2,3} [0-9]+$/.test(filter.q)) {
+      q = filter.q.replace(' ', '')
+    } else {
+      q = filter.q
+    }
     const params = {
       search_fields: 'code,title,description',
-      q: filter.q,
+      q,
       ...filterKeys.reduce(
         (accumulator, value) => ({ ...accumulator, [value]: filter[value] }),
         {}


### PR DESCRIPTION
Added code that detects if the query is a course code with a space in it and removes it before sending it to the backend.

Fixes #77