### PR TITLE
Make header static to avoid overlay

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -56,8 +56,7 @@ const LogoContainer = styled(Link)`
 `
 
 const Container = styled.div`
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 9;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Make the main header non-sticky to avoid overlaying content when scrolling

## Test plan
- [ ] Not run (react-scripts not installed in environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)